### PR TITLE
Refactor: represent multiple statements as linked node

### DIFF
--- a/cc7.h
+++ b/cc7.h
@@ -31,6 +31,7 @@ typedef enum {
   NODE_TYPE_NE,
   NODE_TYPE_NUMBER,
   NODE_TYPE_RETURN,
+  NODE_TYPE_STATEMENT,
   NODE_TYPE_SUBTRACT,
   NODE_TYPE_WHILE,
 } NodeType;
@@ -43,13 +44,6 @@ struct Node {
   Node *rhs;
   int value;
   int offset;
-};
-
-typedef struct Statement Statement;
-
-struct Statement {
-  Statement *next;
-  Node *node;
 };
 
 typedef enum {
@@ -82,11 +76,11 @@ struct Token {
   int length;
 };
 
-void generate_code(Statement *statement);
+void generate_code(Node *node);
 
 Token *tokenize();
 
-Statement *parse(char *string);
+Node *parse(char *string);
 
 void report_error(char *location, char *fmt, ...);
 

--- a/code_generator.c
+++ b/code_generator.c
@@ -131,6 +131,13 @@ void generate_code_for_expression(Node *node) {
   case NODE_TYPE_WHILE:
     generate_code_for_while(node);
     return;
+  case NODE_TYPE_STATEMENT:
+    generate_code_for_expression(node->lhs);
+    if (node->rhs) {
+      printf("  pop rax\n");
+      generate_code_for_expression(node->rhs);
+    }
+    return;
   }
 
   generate_code_for_expression(node->lhs);
@@ -178,15 +185,13 @@ void generate_code_for_expression(Node *node) {
   printf("  push rax\n");
 }
 
-void generate_code(Statement *statement) {
+void generate_code(Node *node) {
   printf(".intel_syntax noprefix\n");
   printf(".global main\n");
   printf("main:\n");
   printf("  push rbp\n");
   printf("  mov rbp, rsp\n");
   printf("  sub rsp, 208\n");
-  for (Statement *current = statement; current; current = current->next) {
-    generate_code_for_expression(current->node);
-  }
+  generate_code_for_expression(node);
   generate_code_for_return();
 }

--- a/parser.c
+++ b/parser.c
@@ -119,18 +119,15 @@ Node *generate_local_variable_node(Token *token) {
   return node;
 }
 
-// program = statements*
-Statement *program() {
-  Statement head;
-  Statement *current = &head;
-
+// program = statements+
+Node *program() {
+  Node *head = generate_branch_node(NODE_TYPE_STATEMENT, statement(), NULL);
+  Node *node = head;
   while (!at_eof()) {
-    current->next = calloc(1, sizeof(Statement));
-    current = current->next;
-    current->node = statement();
+    node->rhs = generate_branch_node(NODE_TYPE_STATEMENT, statement(), NULL);
+    node = node->rhs;
   }
-
-  return head.next;
+  return head;
 }
 
 // statement
@@ -331,7 +328,7 @@ Node *primary() {
   }
 }
 
-Statement *parse(char *string) {
+Node *parse(char *string) {
   user_input = string;
   token = tokenize();
   return program();


### PR DESCRIPTION
これまでは Statement 構造体を利用して連続する複数の文を表現していましたが、Node 構造体で表現する方がシンプルなため、こちらの方式に置き換えます。

```
a; b; c;
```

に対し、

```
NODE_TYPE_STATEMENT
|
|- left -- a
|
`- right - NODE_TYPE_STATEMENT
           |
           |- left -- b
           |
           `- right - NODE_TYPE_STATEMENT
                      |
                      |- left -- c
                      |
                      `- right - NULL
```

のような AST が生成されることになります。

連続する複数の文をこの方式で表現するように変更しておくことで、今後登場する `if (a) { b; c; }` のようなブロック内部の複文も、同じ方式で扱えるようになります。