### PR TITLE
Implement block

### DIFF
--- a/cc7.h
+++ b/cc7.h
@@ -17,6 +17,7 @@ struct LocalVariable {
 typedef enum {
   NODE_TYPE_ADD,
   NODE_TYPE_ASSIGN,
+  NODE_TYPE_BLOCK,
   NODE_TYPE_DIVIDE,
   NODE_TYPE_EQ,
   NODE_TYPE_FOR,

--- a/code_generator.c
+++ b/code_generator.c
@@ -138,6 +138,11 @@ void generate_code_for_expression(Node *node) {
       generate_code_for_expression(node->rhs);
     }
     return;
+  case NODE_TYPE_BLOCK:
+    if (node->rhs) {
+      generate_code_for_expression(node->rhs);
+    }
+    return;
   }
 
   generate_code_for_expression(node->lhs);

--- a/parser.c
+++ b/parser.c
@@ -6,6 +6,8 @@
 
 Node *statement();
 
+Node *statement_block();
+
 Node *statement_expression();
 
 Node *statement_for();
@@ -135,6 +137,7 @@ Node *program() {
 //   | statement_for
 //   | statement_if
 //   | statement_while
+//   | statement_block
 //   | statement_expression
 Node *statement() {
   if (consume_token_type(TOKEN_TYPE_RETURN)) {
@@ -145,9 +148,22 @@ Node *statement() {
     return statement_if();
   } else if (consume_token_type(TOKEN_TYPE_WHILE)) {
     return statement_while();
+  } else if (consume("{")) {
+    return statement_block();
   } else {
     return statement_expression();
   }
+}
+
+// statement_block = "{" statement* "}"
+Node *statement_block() {
+  Node *node = generate_branch_node(NODE_TYPE_BLOCK, NULL, NULL);
+  Node *head = node;
+  while (!consume("}")) {
+    node->rhs = generate_branch_node(NODE_TYPE_STATEMENT, statement(), NULL);
+    node = node->rhs;
+  }
+  return head;
 }
 
 // statement_expression = expression ";"

--- a/test.sh
+++ b/test.sh
@@ -67,4 +67,6 @@ assert 6 "b = 0; for (a = 0; a < 3; a = a + 1) b = b + 2; return b;"
 
 assert 3 "a = 0; while (a < 3) a = a + 1; return a;"
 
+assert 2 "if (1) { a = 2; return a; }"
+
 echo OK

--- a/tokenizer.c
+++ b/tokenizer.c
@@ -60,7 +60,7 @@ Token *tokenize() {
     } else if (starts_with(p, "==") || starts_with(p, "!=") || starts_with(p, "<=") || starts_with(p, ">=")) {
       current = generate_token(TOKEN_TYPE_RESERVED_SYMBOL, current, p, 2);
       p += 2;
-    } else if (strchr("+-*/()<>;=", *p)) {
+    } else if (strchr("+-*/()<>;={}", *p)) {
       current = generate_token(TOKEN_TYPE_RESERVED_SYMBOL, current, p, 1);
       p++;
     } else if (starts_with_keyword(p, "if")) {


### PR DESCRIPTION
```
{ a; b; }
```

のような複文をサポートします。

現状 program が実質中括弧の中身とほぼ同等の構文なので、同じ実装でいけます。もしかすると、program も NODE_TYPE_BLOCK な Node* を返すように実装した方が綺麗かもしれません。とはいえ、最終的には main 関数が呼び出されるようになりそうなので、ブロックで表現するのは誤りかもしれません。

また、現状 `""` や `"{}"`のようなプログラムが何を返すべきなのか判断しかねています。