### PR TITLE
Remove Node#offset (substitute with Node#value)

### DIFF
--- a/cc7.h
+++ b/cc7.h
@@ -44,7 +44,6 @@ struct Node {
   Node *lhs;
   Node *rhs;
   int value;
-  int offset;
 };
 
 typedef enum {

--- a/code_generator.c
+++ b/code_generator.c
@@ -28,7 +28,7 @@ void generate_code_for_local_variable(Node *node) {
   }
 
   printf("  mov rax, rbp\n");
-  printf("  sub rax, %d\n", node->offset);
+  printf("  sub rax, %d\n", node->value);
   printf("  push rax\n");
 }
 

--- a/parser.c
+++ b/parser.c
@@ -116,7 +116,7 @@ Node *generate_local_variable_node(Token *token) {
     local_variable->next = local_variables;
     local_variables = local_variable;
   }
-  node->offset = local_variable->offset;
+  node->value = local_variable->offset;
 
   return node;
 }


### PR DESCRIPTION
ローカル変数用の Node に、関数フレームの先頭アドレス (RBP) からの offset を紐付けておくために、これまで offset という int 型のメンバを用意していました。これは NODE_TYPE_LOCAL_VARIABLE でしか利用されていません。しかし Node には、NODE_TYPE_NUMBER でしか利用しない value という int 型のメンバが既に存在します。

そこで、NODE_TYPE_LOCAL_VARIABLE でも value を offset 格納用のメンバとして利用することで、offset メンバを廃止します。