### PR TITLE
Raise error if some diff found after make format on CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,7 @@ jobs:
           GITHUB_PACKAGE_REGISTRY_TOKEN: ${{ secrets.GITHUB_PACKAGE_REGISTRY_TOKEN }}
       - run: docker-compose pull
       - run: docker-compose run --rm base make format
+      - run: git diff --color --exit-code
 
   test:
     runs-on: ubuntu-18.04


### PR DESCRIPTION
CI で clang-format を動かすようにしていましたが、diff の有無に関わらず常に成功してしまうので、diff があれば job を失敗させるようにしました。