### PR TITLE
Implement pointer type

### DIFF
--- a/parser.h
+++ b/parser.h
@@ -1,15 +1,23 @@
 #pragma once
 
+typedef enum {
+  TYPE_TYPE_INTEGER,
+  TYPE_TYPE_POINTER,
+} TypeType;
+
+typedef struct Type Type;
+
+struct Type {
+  TypeType type;
+  Type *pointer;
+};
+
 typedef struct LocalVariable LocalVariable;
 
 struct LocalVariable {
-  // For linked list.
   LocalVariable *next;
-
-  // Variable name. (e.g. "foo")
+  Type *type;
   char *name;
-
-  // Variable name length. (e.g. 3)
   int name_length;
 
   // Offset from RBP. (e.g. 8, 16, 24)
@@ -85,6 +93,7 @@ struct Node {
     } function_call;
 
     struct {
+      Type *return_value_type;
       char *name;
       int name_length;
       Nodes *parameters;

--- a/test.sh
+++ b/test.sh
@@ -98,4 +98,6 @@ assert 2 "int main() { int a; int b; a = 2; b = &a; return *b; }"
 # initializer
 assert 2 "int main() { int a = 2; return a; }"
 
+assert 1 "int *f() { int a = 0; int *b = &a; return b; } int main() { return 1; }"
+
 echo OK


### PR DESCRIPTION
Note: the type information is currently not used for any purpose. Both integer and pointer type have  same 8 byte length for now, so we don't need to adjust memory offset by their types.